### PR TITLE
Relax over-specified constraint on hspec.

### DIFF
--- a/web-routes-th.cabal
+++ b/web-routes-th.cabal
@@ -23,7 +23,7 @@ test-suite Test
   main-is          : Test.hs
   hs-source-dirs   : test
   build-depends    : base == 4.*,
-                     hspec >= 2.2 && < 2.7,
+                     hspec >= 2.2 && < 2.8,
                      HUnit,
                      QuickCheck,
                      web-routes,


### PR DESCRIPTION
Building and running the test suite with hspec 2.7.x works just fine.